### PR TITLE
Remove flag from tftp-http-proxy's service file

### DIFF
--- a/templates/mr-provisioner-tftp.service.j2
+++ b/templates/mr-provisioner-tftp.service.j2
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 ExecStart={{mr_provisioner_path}}/bin/tftp-http-proxy \
-	-http-base-url 'http://{{mr_provisioner_public_addr}}:{{mr_provisioner_public_port}}/tftp/' -log-path '{{mr_provisioner_path}}/logs/tftp-http-proxy.log' -tftp-bind-address '{{mr_provisioner_public_addr}}:69'
+	-http-base-url 'http://{{mr_provisioner_public_addr}}:{{mr_provisioner_public_port}}/tftp/' -tftp-bind-address '{{mr_provisioner_public_addr}}:69'
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
Since a couple of months, I have observed that the --log-path flag doesn't exist for tftp-http-proxy.
I was absolutely sure to have upstreamed this patch but it seems it was only in my local copy...

Very sorry about that !